### PR TITLE
Made UA detection case-insensitive.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,5 +1,5 @@
 var bots = require('./bots');
-var regex = new RegExp('\\b' + bots.join('\\b|\\b') + '\\b');
+var regex = new RegExp('\\b' + bots.join('\\b|\\b') + '\\b', 'i');
 
 module.exports = exports = function (options) {
     if (!options) {


### PR DESCRIPTION
I was testing this with the most basic bot user agent that Google Chrome has to offer: `Googlebot`.
Unfortunately the list of user agents included in this package lists `googlebot` with a lowercase G.

Now as different casing (maybe historical reasons?) could be a thing for most bots in this list, instead of adapting and testing every single bot user agent component, I decided to just make the RegExp function case-insensitive.

This should solve this problem elegantly enough.